### PR TITLE
Use our Docker meta step for CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,31 +2,40 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
 
 jobs:
-
-  build:
-
+  docker:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2   
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - name: Build and push latest
-        uses: docker/build-push-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: zazukoians/node-java
-          tags: latest
 
-      - name: Build and push tagged
-        uses: docker/build-push-action@v1
+      - name: Docker meta
+        uses: zazuko/action-docker-meta@main
+        id: docker_meta
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: zazukoians/node-java
-          tag_with_ref: true
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          images: docker.io/zazukoians/node-java
+
+      - name: Build and push Docker images
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
This will push the Docker image at `docker.io/zazukoians/node-java` on each commit with our standardized tags (it will use our [`action-docker-meta`](https://github.com/zazuko/action-docker-meta) GitHub Action):
- `vX`, `vX.Y`, `vX.Y.Z` for semver tags
- `branch-[name of branch]`
- `git-[sha]`
- `pipeline-[id of pipeline]`
- `latest` if you pushed on the main branch

Just make sure that `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets are defined.